### PR TITLE
Fix: return focus to editor after toolbar selection

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -14,6 +14,7 @@ const postAceInit = (hook, context) => {
         ace.ace_doInsertColors(intValue);
       }, 'insertColor', true);
       hs.val('dummy');
+      context.ace.focus();
     }
   });
   $('.font_color').hover(() => {
@@ -22,6 +23,7 @@ const postAceInit = (hook, context) => {
   });
   $('.font-color-icon').click(() => {
     $('#font-color').toggle();
+    context.ace.focus();
   });
 };
 


### PR DESCRIPTION
## Summary

Focus was lost from the editor after selecting from the toolbar dropdown. Added `context.ace.focus()` after the selection is applied so users can keep typing immediately.

Same fix as ether/ep_headings2#149.

## Test plan

- [ ] Select from the dropdown — cursor should remain in the editor
- [ ] Verify selection still applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)