### PR TITLE
Add Dependabot automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot Automerge
+permissions:
+  contents: write
+  pull-requests: write
+on:
+  workflow_run:
+    workflows:
+      - Node.js Package
+    types:
+      - completed
+
+jobs:
+  automerge:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Automerge
+        uses: "pascalgn/automerge-action@v0.16.4"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_METHOD: squash
+          MERGE_LABELS: ""
+          MERGE_RETRY_SLEEP: "100000"


### PR DESCRIPTION
Auto-merges Dependabot PRs after CI passes. This will unblock the 4 pending Dependabot PRs (#118, #119, #122, #123).

Matches the pattern used in ether/ueberDB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)