### PR TITLE
fix: demote ERR_PNPM_IGNORED_BUILDS to warning in publish step

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -17,6 +17,11 @@ jobs:
     permissions:
       contents: write   # for the atomic version-bump push (branch + tag)
       id-token: write   # for npm OIDC trusted publishing
+    env:
+      # pnpm 10.7+ treats ignored postinstalls as hard errors. Demote
+      # to warning so new transitive deps (e.g. unrs-resolver) don\'t break
+      # the release step.
+      npm_config_strict_dep_builds: "false"
     steps:
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
pnpm 10.7+ treats ignored postinstalls as hard errors. A new transitive dep (`unrs-resolver@1.11.1` via `eslint-config-etherpad` → `eslint-import-resolver-typescript`) ships a postinstall that isn't in any allowlist, which fails every plugin's release job.

Set `npm_config_strict_dep_builds=false` as a job-level env var in the publish workflow so pnpm warns instead of failing. The allowlist in etherpad-lite's `pnpm-workspace.yaml` still controls what actually runs.

Generated with [Claude Code](https://claude.com/claude-code)