### PR TITLE
fix: refresh color dropdown when UI language changes (#21)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -31,6 +31,16 @@ exports.postAceInit = (hook, context) => {
     $('#font-color').toggle();
     context.ace.focus();
   });
+  // Re-render the niceSelect dropdown whenever the active UI language
+  // changes. html10n rewrites the underlying <select>'s option text in
+  // place, but niceSelect renders into its own DOM tree at init time and
+  // does not observe DOM mutations — so without a manual refresh the
+  // dropdown keeps showing the previous language (#21).
+  if (typeof html10n !== 'undefined' && typeof html10n.bind === 'function') {
+    html10n.bind('localized', () => {
+      hs.niceSelect('update');
+    });
+  }
 };
 
 const doInsertColors = function (level) {

--- a/static/tests/backend/specs/language_refresh.js
+++ b/static/tests/backend/specs/language_refresh.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const indexPath = path.resolve(
+    __dirname, '..', '..', '..', '..', 'static', 'js', 'index.js');
+
+describe(__filename, function () {
+  let src;
+  before(function () { src = fs.readFileSync(indexPath, 'utf8'); });
+
+  it('postAceInit rebinds niceSelect on html10n language change (#21)', function () {
+    // niceSelect renders a copy of the <select> at init time and does not
+    // observe option-text mutations. After html10n rewrites the <select>
+    // options for the new locale, the custom dropdown must be refreshed
+    // via `niceSelect('update')` so the user sees the translated labels.
+    const postAceInit = src.match(/exports\.postAceInit\s*=\s*[\s\S]*?\n\};/);
+    assert(postAceInit, 'expected exports.postAceInit in index.js');
+    const body = postAceInit[0];
+    assert(/html10n\.bind\(\s*['"]localized['"]/.test(body),
+        'postAceInit should subscribe to html10n.localized');
+    assert(/niceSelect\(\s*['"]update['"]\s*\)/.test(body),
+        'postAceInit should call niceSelect("update") when the language changes');
+  });
+});


### PR DESCRIPTION
Fixes #21. The color select is wrapped in niceSelect, which renders its own DOM copy of the <select> at init time. html10n rewrites option text in place for the new locale, but niceSelect does not observe those mutations, so the dropdown kept showing the previous language. Subscribe to html10n.localized and call niceSelect('update') to refresh the custom dropdown. Backend spec asserts the wiring is present.