### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ep_font_color
+# Font Colors for Etherpad
 
 ![Demo](demo.gif)
 


### PR DESCRIPTION
Replace the placeholder `ep_font_color` heading in README.md with "Font Colors for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.