### PR TITLE
fix: group Font Color with other font-formatting menu entries (#35)

### DIFF
--- a/templates/fileMenu.ejs
+++ b/templates/fileMenu.ejs
@@ -1,4 +1,3 @@
-<hr>
 <li><a href="#" data-key="align" class="font_color">Font Color</a>
   <ul class="submenu">
     <select class="color-selection">


### PR DESCRIPTION
Fixes #35. The Font Color file-menu entry had a leading `<hr>`, so it rendered as its own standalone group after a separator — away from Font Size / Font Family where it logically belongs. Drop the `<hr>` and the entries collapse into the same formatting group.