### PR TITLE
fix: read text-color from inline style on HTML import

### DIFF
--- a/static/js/shared.js
+++ b/static/js/shared.js
@@ -4,5 +4,40 @@ const {inlineAttribute} = require('ep_plugin_helpers/attributes');
 
 const fontColor = inlineAttribute({attr: 'color'});
 
-exports.collectContentPre = fontColor.collectContentPre;
+// Read a `style="color:..."` declaration on imported HTML and apply
+// the matching `color::<value>` attribute. The `inlineAttribute` factory
+// only reads `class="color:red"` (the form ep_font_color emits on
+// export), so without this any externally-pasted HTML using the
+// standard CSS form would silently lose color.
+const STYLE_COLOR_RE = /(?:^|;|\s)color\s*:\s*([^;]+?)\s*(?:;|$)/i;
+// Allowed values match the toolbar palette + a few CSS keywords.
+const ALLOWED_COLORS = new Set([
+  'black', 'red', 'green', 'blue', 'yellow', 'orange',
+]);
+
+const NAMED_TO_PALETTE = (raw) => {
+  const v = raw.toLowerCase().trim();
+  if (ALLOWED_COLORS.has(v)) return v;
+  // Word/LibreOffice often emit hex (e.g. #FF0000). Fold common values
+  // back to palette names; everything else falls through.
+  if (/^#?ff0+0+$/i.test(v)) return 'red';
+  if (/^#?0+ff0+$/i.test(v) || /^#?008000$/i.test(v)) return 'green';
+  if (/^#?0+0+ff$/i.test(v)) return 'blue';
+  if (/^#?ffff0+$/i.test(v)) return 'yellow';
+  if (/^#?ff[ab]?500$/i.test(v) || v === 'orange') return 'orange';
+  if (/^#?0+$/i.test(v) || v === 'black') return 'black';
+  return null;
+};
+
+const collectContentPreOrig = fontColor.collectContentPre;
+exports.collectContentPre = (hookName, context) => {
+  collectContentPreOrig(hookName, context);
+  if (context.styl) {
+    const m = STYLE_COLOR_RE.exec(context.styl);
+    if (m) {
+      const color = NAMED_TO_PALETTE(m[1]);
+      if (color) context.cc.doAttrib(context.state, `color::${color}`);
+    }
+  }
+};
 exports.collectContentPost = fontColor.collectContentPost;

--- a/static/tests/backend/specs/api/exportHTML.js
+++ b/static/tests/backend/specs/api/exportHTML.js
@@ -212,4 +212,30 @@ describe('export color styles to HTML', function () {
           });
     });
   });
+
+  // Round-trip via inline `style="color:..."`. External HTML (Word
+  // exports, mammoth output, pasted markup) typically uses the standard
+  // CSS form, not the `class="color:red"` form ep_font_color emits on
+  // export. Without the import-side style reader, color is lost.
+  context('when imported HTML uses style="color:..."', function () {
+    for (const color of ['red', 'green', 'blue']) {
+      it(`preserves style="color:${color}" through round-trip`, async function () {
+        const newPadID = randomString(5);
+        await createPad(newPadID);
+        await setHTML(newPadID, buildHTML(
+            `<p>before <span style="color:${color}">styled</span> after</p>`));
+        await agent.get(getHTMLEndPointFor(newPadID))
+            .set('Authorization', await common.generateJWTToken())
+            .expect((res) => {
+              const out = res.body.data.html;
+              const re = new RegExp(
+                  `(class=["'].*color:${color}|data-color=["']${color})`);
+              if (!re.test(out)) {
+                throw new Error(
+                    `Color not preserved on style-import round-trip. Got: ${out}`);
+              }
+            });
+      });
+    }
+  });
 });


### PR DESCRIPTION
## Problem

`getLineHTMLForExport` emits `class="color:<name>"` on export. `inlineAttribute.collectContentPre` reads the class attribute on import, so the export → import round-trip works for our own output.

But external HTML (Word/DOCX via mammoth, pasted from a browser, etc.) uses the standard CSS form `style="color:red"`. The factory does not touch `context.styl`, so externally-pasted color is silently dropped — and any DOCX round-trip via [`ether/etherpad#7568`](https://github.com/ether/etherpad/pull/7568)'s native path ends up with no color on import.

## Fix

Wrap the factory's `collectContentPre` to also scan `context.styl` for `color:...`. Match the value back to the toolbar palette (`black`, `red`, `green`, `blue`, `yellow`, `orange`); fold common hex equivalents (e.g. `#FF0000` → `red`) so Word's hex output round-trips too.

## Tests

`static/tests/backend/specs/api/exportHTML.js`: new context block, three test cases asserting that a pad imported with `<span style="color:<name>">styled</span>` re-exports as `class="color:<name>"` (or the `data-color` fallback). Covers `red`, `green`, `blue`.

Refs `ether/etherpad#7568`. Sister PR for `text-align`: `ether/ep_align#183` (merged).