### PR TITLE
a11y: restore aria-label on <select> (html10n cannot auto-populate)

### DIFF
--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -5,7 +5,7 @@
   </a>
 </li>
 <li id="font-color" class="acl-write" style="display:none;">
-    <select class="color-selection"
+    <select aria-label="Font color" class="color-selection"
             data-l10n-id="ep_font_color.color">
         <option value="dummy" selected data-l10n-id="ep_font_color.color">Color</option>
         <option value="0" data-l10n-id="ep_font_color.black">black</option>


### PR DESCRIPTION
## Summary

Reverts the `aria-label` removal on the `<select>` element introduced by the previous Phase 3a sweep (#154).

**Why this needed reverting:** etherpad's html10n only auto-populates `aria-label` for elements with no children (or when the data-l10n-id has an attribute suffix like `.title`). `<select>` elements always have `<option>` children, so the fallback at `html10n.ts:665-678` is bypassed. After the previous PR, the `<select>` was left with no accessible name at all.

This is a stopgap — the hardcoded English aria-label is back, which is bad for translated UI but better than no accessible name. The proper fix is a small change to `html10n.ts` to populate aria-label on form-controllable elements (`<select>`, `<input>`, `<textarea>`) regardless of children. That should be a follow-up PR against ether/etherpad.