### PR TITLE
feat: migrate to ep_plugin_helpers/toolbar-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://etherpad.org/"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.5.3"
+    "ep_plugin_helpers": "^0.6.0"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://etherpad.org/"
   },
   "dependencies": {
-    "ep_plugin_helpers": "^0.6.0"
+    "ep_plugin_helpers": "^0.6.1"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {inlineAttribute} = require('ep_plugin_helpers/attributes');
+const {toolbarSelect} = require('ep_plugin_helpers/toolbar-select');
 
 const colors = ['black', 'red', 'green', 'blue', 'yellow', 'orange'];
 
@@ -11,17 +12,11 @@ exports.aceCreateDomLine = fontColor.aceCreateDomLine;
 
 // Bind the event handler to the toolbar buttons
 exports.postAceInit = (hook, context) => {
-  const hs = $('.color-selection, #color-selection');
-  hs.on('change', function () {
-    const value = $(this).val();
-    const intValue = parseInt(value, 10);
-    if (!isNaN(intValue)) {
-      context.ace.callWithAce((ace) => {
-        ace.ace_doInsertColors(intValue);
-      }, 'insertColor', true);
-      hs.val('dummy');
-      context.ace.focus();
-    }
+  const {$sel: hs} = toolbarSelect({
+    selector: '.color-selection, #color-selection',
+    context,
+    invoke: (ace, value) => ace.ace_doInsertColors(value),
+    op: 'insertColor',
   });
   $('.font_color').hover(() => {
     $('.submenu > .color-selection').attr('size', 6);


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `<select>` change handler with the shared `toolbarSelect` helper from [ep_plugin_helpers#17](https://github.com/ether/ep_plugin_helpers/pull/17).

```diff
- const hs = $('.color-selection, #color-selection');
- hs.on('change', function () {
-   const value = $(this).val();
-   const intValue = parseInt(value, 10);
-   if (!isNaN(intValue)) {
-     context.ace.callWithAce((ace) => {
-       ace.ace_doInsertColors(intValue);
-     }, 'insertColor', true);
-     hs.val('dummy');
-     context.ace.focus();
-   }
- });
+ toolbarSelect({
+   selector: '.color-selection, #color-selection',
+   context,
+   invoke: (ace, value) => ace.ace_doInsertColors(value),
+   op: 'insertColor',
+ });
```

## Behavioral notes

- Same int coercion, same `callWithAce` op label, same `'dummy'` sentinel reset.
- The helper restores focus **unconditionally** (even on an unusable pick). The previous code only restored focus when the int coerce succeeded; on a no-op pick, focus stayed on the `<select>`. Restoring focus always is the WCAG-friendly default and matches what ep_headings2 already did.

## Status

**Draft** — depends on:
1. https://github.com/ether/ep_plugin_helpers/pull/17 merging
2. ep_plugin_helpers ≥ 0.6.0 published to npm

Mark ready and update the dep range (already `^0.6.0` in package.json) once both happen.

Refs https://github.com/ether/etherpad/issues/7255

🤖 Generated with [Claude Code](https://claude.com/claude-code)